### PR TITLE
Added open browser plugin to package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "file-loader": "0.9.0",
     "html-webpack-plugin": "^2.24.1",
     "json-loader": "^0.5.4",
+    "open-browser-webpack-plugin": "0.0.3",
     "postcss-loader": "^1.1.1",
     "react-hot-loader": "^3.0.0-beta.6",
     "style-loader": "0.13.1",


### PR DESCRIPTION
The repo assumes that `open Browser Plugin` is installed globally. Its not. This PR adds it to the `package.json`.