### PR TITLE
Links: update to CSS, semantic HTML

### DIFF
--- a/src/components/SlideSubContentList/SlideSubContentList.scss
+++ b/src/components/SlideSubContentList/SlideSubContentList.scss
@@ -23,5 +23,7 @@
   }
   a {
     text-decoration: none;
+    color: var(--app-blue);
+    font-weight: 400;
   }
 }

--- a/src/components/SlideSubContentList/index.js
+++ b/src/components/SlideSubContentList/index.js
@@ -15,9 +15,9 @@ class SlideSubContentList extends Component {
       if (point) {
         if (href) {
           return (
-            <Link href={href} target="_blank">
-              <li>{point}</li>
-            </Link>
+            <li>
+              <Link href={href} target="_blank">{point}</Link>
+            </li>
           )
         }
         return <li className={classnames({[styles.isQuote]: quote })}>{point}</li>


### PR DESCRIPTION
Before this PR, links appeared the same as normal `<li>`'s:

<img width="1276" alt="screen shot 2017-01-15 at 4 41 04 pm" src="https://cloud.githubusercontent.com/assets/17211269/21966458/758cbc00-db41-11e6-8072-fc91a4c2d4db.png">

Also changed is the reformatting of how links appear within `<li>`s, previously they didn't follow a semantic HTML structure. 