### PR TITLE
JSON: Use double quotes

### DIFF
--- a/src/app/data/data.json
+++ b/src/app/data/data.json
@@ -59,7 +59,7 @@
           "title": "Reusing code",
           "points": [
             {
-              "point": "'Reusable components'",
+              "point": "\"Reusable components\"",
               "href": "",
               "quote": false
             },
@@ -100,7 +100,7 @@
               "quote": false
             },
             {
-              "point": "Re-rendering of page on 'state' change",
+              "point": "Re-rendering of page on \"state\" change",
               "href": "",
               "quote": false
             }


### PR DESCRIPTION
This PR allows the JSON to escape the obvious use of double quotes within a double-quote strings. The structure could be better on my end (maybe I should switch to single quotes?) but for these small instances this should suffice. 