### PR TITLE
Mobile friendly styling

### DIFF
--- a/src/components/Hero/Hero.scss
+++ b/src/components/Hero/Hero.scss
@@ -1,14 +1,19 @@
 // All Hero styles go here
 
 .heroContainer {
-  height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding-bottom: 200px;
   color: var(--app-white);
   .reactHighlight {
     color: var(--app-blue);
+  }
+  @media only screen and (min-width: 768px) {
+    height: 100vh;
+    padding-bottom: 200px;
+  }
+  @media only screen and (max-width: 767px) {
+    padding: 50px 20px 150px 20px;
   }
 }

--- a/src/components/Image/Image.scss
+++ b/src/components/Image/Image.scss
@@ -1,5 +1,10 @@
 // All Image styles go here
 
 .hero {
-  height: 300px;
+  @media only screen and (min-width: 768px) {
+    height: 300px;
+  }
+  @media only screen and (max-width: 767px) {
+    width: 50%;
+  }
 }

--- a/src/components/Slide/Slide.scss
+++ b/src/components/Slide/Slide.scss
@@ -1,6 +1,5 @@
 .slide {
   width: 100vw;
-  padding: 50px;
   color: var(--app-white);
   display: flex;
   flex-direction: column;
@@ -13,11 +12,22 @@
     border-top: 1px solid var(--app-white);
     margin-bottom: 15px;
     padding-bottom: 15px;
-    height: 100vh;
     width: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
     text-align: center;
+  }
+  @media only screen and (min-width: 768px) {
+    padding: 50px;
+    h1 {
+      height: 100vh;
+    }
+  }
+  @media only screen and (max-width: 767px) {
+    h1 {
+      padding: 0 10px;
+      height: 275px;
+    }
   }
 }

--- a/src/components/SlideMedia/SlideMedia.scss
+++ b/src/components/SlideMedia/SlideMedia.scss
@@ -1,5 +1,10 @@
 .SlideMedia {
   width: 85%;
   display: block;
-  margin: 100px auto;
+  @media only screen and (min-width: 768px) {
+    margin: 100px auto;
+  }
+  @media only screen and (max-width: 767px) {
+    margin: 25px auto;
+  }
 }

--- a/src/components/SlideSubContent/SlideSubContent.scss
+++ b/src/components/SlideSubContent/SlideSubContent.scss
@@ -1,13 +1,28 @@
 .SlideSubContent {
-  margin: 125px 0;
-  min-height: 100vh;
   padding-top: 50px;
   border-top: 1px solid var(--app-white);
-  &:first-child {
-    margin-top: 50px;
+  
+  &:not(:first-child) {
+    margin: 125px 0;
+  }
+  &:last-child {
+    padding-bottom: 50px;
   }
   h2 {
-    padding: 25px 0;
     color: var(--app-blue);
+  }
+  @media only screen and (min-width: 768px) {
+    min-height: 100vh;
+    h2 {
+      padding: 25px 0;
+    }
+  }
+  @media only screen and (max-width: 767px) {
+    h2 {
+      padding: 25px;
+    }
+    ul {
+      padding: 0 20px;
+    }
   }
 }

--- a/src/components/SlideSubContentList/SlideSubContentList.scss
+++ b/src/components/SlideSubContentList/SlideSubContentList.scss
@@ -2,9 +2,14 @@
   a,
   li {
     color: var(--app-white);
-    font-size: 38px;
     padding: 12.5px 0;
     font-weight: 100;
+    @media only screen and (min-width: 768px) {
+      font-size: 38px;
+    }
+    @media only screen and (max-width: 767px) {
+      font-size: 22px;
+    }
   }
   li {
     &:not(.isQuote) {

--- a/src/globalStyles/typography.scss
+++ b/src/globalStyles/typography.scss
@@ -50,30 +50,49 @@ dd {
   font-weight: lighter;
 }
 
-h1 {
-  font-size: 72px;
+@media only screen and (min-width: 728px) {
+  h1 {
+    font-size: 72px;
+  }
+  h2 {
+    font-size: 48px;
+  }
+  h3 {
+    font-size: 42px;
+  }
+  h4 {
+    font-size: 38px;
+  }
+  h5 {
+    font-size: 34px;
+  }
+  h6 {
+    font-size: 20px;
+  }
+  p {
+    font-size: 16px;
+  }
 }
-
-h2 {
-  font-size: 48px;
-}
-
-h3 {
-  font-size: 42px;
-}
-
-h4 {
-  font-size: 38px;
-}
-
-h5 {
-  font-size: 34px;
-}
-
-h6 {
-  font-size: 20px;
-}
-
-p {
-  font-size: 16px;
+@media only screen and (max-width: 727px) {
+  h1 {
+    font-size: 38px;
+  }
+  h2 {
+    font-size: 32px;
+  }
+  h3 {
+    font-size: 28px;
+  }
+  h4 {
+    font-size: 24px;
+  }
+  h5 {
+    font-size: 20px;
+  }
+  h6 {
+    font-size: 16px;
+  }
+  p {
+    font-size: 13px;
+  }
 }

--- a/src/globalStyles/typography.scss
+++ b/src/globalStyles/typography.scss
@@ -50,7 +50,7 @@ dd {
   font-weight: lighter;
 }
 
-@media only screen and (min-width: 728px) {
+@media only screen and (min-width: 768px) {
   h1 {
     font-size: 72px;
   }
@@ -73,7 +73,7 @@ dd {
     font-size: 16px;
   }
 }
-@media only screen and (max-width: 727px) {
+@media only screen and (max-width: 767px) {
   h1 {
     font-size: 38px;
   }


### PR DESCRIPTION
How it looks on Mobile now:

<img width="374" alt="screen shot 2017-02-26 at 3 03 55 pm" src="https://cloud.githubusercontent.com/assets/17211269/23343156/db4db2a6-fc34-11e6-939e-c9524aeecafd.png">
<img width="373" alt="screen shot 2017-02-26 at 3 04 02 pm" src="https://cloud.githubusercontent.com/assets/17211269/23343157/db5a96b0-fc34-11e6-825f-7dee8f20c326.png">
<img width="356" alt="screen shot 2017-02-26 at 3 04 11 pm" src="https://cloud.githubusercontent.com/assets/17211269/23343158/db5bb270-fc34-11e6-99c6-341e002b6411.png">

