### PR TITLE
Slide media: sit below titles

### DIFF
--- a/src/components/SlideSubContent/index.js
+++ b/src/components/SlideSubContent/index.js
@@ -9,8 +9,8 @@ const SlideTitle = ({ innerHtml }) => (
 
 const SlideContainer = ({ title, points, media }) => (
   <div className={styles.SlideSubContent}>
-    <SlideMedia source={media} />
     <SlideTitle innerHtml={title} />
+    <SlideMedia source={media} />
     <SlideSubContentList point={points} />
   </div>
 );


### PR DESCRIPTION
This PR moves the slideMedia component below the titles to initiate a more user-friendly experience.